### PR TITLE
Fix bank quickbuff not applying extra duration from charms

### DIFF
--- a/AlchemistNPCLitePlayer.cs
+++ b/AlchemistNPCLitePlayer.cs
@@ -40,26 +40,26 @@ using AlchemistNPCLite.Items;
 
 namespace AlchemistNPCLite
 {
-    public class AlchemistNPCLitePlayer : ModPlayer
-    {
-        public bool BoomBox = false;
-        public bool DistantPotionsUse = false;
-        public bool Voodoo = false;
-        public bool Luck = false;
-        public bool AlchemistCharmTier1 = false;
-        public bool AlchemistCharmTier2 = false;
-        public bool AlchemistCharmTier3 = false;
-        public bool AlchemistCharmTier4 = false;
-        public bool Traps = false;
-        public bool ModPlayer = true;
+	public class AlchemistNPCLitePlayer : ModPlayer
+	{
+		public bool BoomBox = false;
+		public bool DistantPotionsUse = false;
+		public bool Voodoo = false;
+		public bool Luck = false;
+		public bool AlchemistCharmTier1 = false;
+		public bool AlchemistCharmTier2 = false;
+		public bool AlchemistCharmTier3 = false;
+		public bool AlchemistCharmTier4 = false;
+		public bool Traps = false;
+		public bool ModPlayer = true;
 
-        public bool AllDamage10 = false;
-        public bool AllCrit10 = false;
-        public bool Defense8 = false;
-        public bool DR10 = false;
-        public bool Regeneration = false;
-        public bool Lifeforce = false;
-        public bool MS = false;
+		public bool AllDamage10 = false;
+		public bool AllCrit10 = false;
+		public bool Defense8 = false;
+		public bool DR10 = false;
+		public bool Regeneration = false;
+		public bool Lifeforce = false;
+		public bool MS = false;
 		public bool Bewitched = false;
 		public bool Sharpen = false;
 		public bool Clairvoyance = false;
@@ -67,27 +67,27 @@ namespace AlchemistNPCLite
 		public bool SugarRush = false;
 		public bool Lamps = false;
 
-        public override void ResetEffects()
-        {
-            BoomBox = false;
-            DistantPotionsUse = false;
-            Luck = false;
-            AlchemistGlobalItem.Luck = false;
-            AlchemistGlobalItem.Luck2 = false;
-            AlchemistNPCLite.GreaterDangersense = false;
-            AlchemistCharmTier1 = false;
-            AlchemistCharmTier2 = false;
-            AlchemistCharmTier3 = false;
-            AlchemistCharmTier4 = false;
-            Traps = false;
+		public override void ResetEffects()
+		{
+			BoomBox = false;
+			DistantPotionsUse = false;
+			Luck = false;
+			AlchemistGlobalItem.Luck = false;
+			AlchemistGlobalItem.Luck2 = false;
+			AlchemistNPCLite.GreaterDangersense = false;
+			AlchemistCharmTier1 = false;
+			AlchemistCharmTier2 = false;
+			AlchemistCharmTier3 = false;
+			AlchemistCharmTier4 = false;
+			Traps = false;
 
-            AllDamage10 = false;
-            AllCrit10 = false;
-            Defense8 = false;
-            DR10 = false;
-            Regeneration = false;
-            Lifeforce = false;
-            MS = false;
+			AllDamage10 = false;
+			AllCrit10 = false;
+			Defense8 = false;
+			DR10 = false;
+			Regeneration = false;
+			Lifeforce = false;
+			MS = false;
 			Bewitched = false;
 			Sharpen = false;
 			Clairvoyance = false;
@@ -95,46 +95,46 @@ namespace AlchemistNPCLite
 			SugarRush = false;
 			Lamps = false;
 
-            if (Main.netMode != NetmodeID.Server)
-            {
-                if (Main.player[Main.myPlayer].talkNPC == -1)
-                {
-                    ShopChangeUI.visible = false;
-                    ShopChangeUIA.visible = false;
-                    ShopChangeUIO.visible = false;
-                    ShopChangeUIM.visible = false;
-                }
-            }
-        }
-
-
-        public override void clientClone(ModPlayer clientClone)
-        {
-            AlchemistNPCLitePlayer clone = clientClone as AlchemistNPCLitePlayer;
-        }
-
-        public override void SendClientChanges(ModPlayer clientPlayer)
-        {
-        }
-
-        // replaced when ported
-        // public override void UpdateEquips(ref bool wallSpeedBuff, ref bool tileSpeedBuff, ref bool tileRangeBuff)
-        public override void UpdateEquips()
-        {
-            ModLoader.TryGetMod("CalamityMod", out Mod Calamity);
-			if(Calamity != null)
+			if (Main.netMode != NetmodeID.Server)
 			{
-                Calamity.TryFind<ModBuff>("HolyWrathBuff", out ModBuff buff);
-				if (buff != null && !Player.HasBuff(buff.Type) && AllDamage10) Player.GetDamage(DamageClass.Generic)+= 0.1f;
-                Calamity.TryFind<ModBuff>("ProfanedRageBuff", out buff);
+				if (Main.player[Main.myPlayer].talkNPC == -1)
+				{
+					ShopChangeUI.visible = false;
+					ShopChangeUIA.visible = false;
+					ShopChangeUIO.visible = false;
+					ShopChangeUIM.visible = false;
+				}
+			}
+		}
+
+
+		public override void clientClone(ModPlayer clientClone)
+		{
+			AlchemistNPCLitePlayer clone = clientClone as AlchemistNPCLitePlayer;
+		}
+
+		public override void SendClientChanges(ModPlayer clientPlayer)
+		{
+		}
+
+		// replaced when ported
+		// public override void UpdateEquips(ref bool wallSpeedBuff, ref bool tileSpeedBuff, ref bool tileRangeBuff)
+		public override void UpdateEquips()
+		{
+			ModLoader.TryGetMod("CalamityMod", out Mod Calamity);
+			if (Calamity != null)
+			{
+				Calamity.TryFind<ModBuff>("HolyWrathBuff", out ModBuff buff);
+				if (buff != null && !Player.HasBuff(buff.Type) && AllDamage10) Player.GetDamage(DamageClass.Generic) += 0.1f;
+				Calamity.TryFind<ModBuff>("ProfanedRageBuff", out buff);
 				if (buff != null && !Player.HasBuff(buff.Type) && AllCrit10)
 				{
 					Player.GetCritChance(DamageClass.Melee) += 10;
 					Player.GetCritChance(DamageClass.Ranged) += 10;
 					Player.GetCritChance(DamageClass.Magic) += 10;
 					Player.GetCritChance(DamageClass.Throwing) += 10;
-                    // IMPLEMENT WHEN WEAKREFERENCES FIXED
-                    /*
+					// IMPLEMENT WHEN WEAKREFERENCES FIXED
+					/*
 					if (ModLoader.GetMod("ThoriumMod") != null)
 					{
 						ThoriumBoosts(Player);
@@ -143,10 +143,10 @@ namespace AlchemistNPCLite
 					{
 						RedemptionBoost(Player);
 					}
-                    */
+					*/
 					Calamity.Call("AddRogueCrit", Player, 10);
 				}
-                Calamity.TryFind<ModBuff>("CadancesGrace", out buff);
+				Calamity.TryFind<ModBuff>("CadancesGrace", out buff);
 				if (!Player.HasBuff(ModContent.BuffType<Buffs.CalamityComb>()) && buff != null && !Player.HasBuff(buff.Type) && Regeneration) Player.lifeRegen += 4;
 				if (!Player.HasBuff(ModContent.BuffType<Buffs.CalamityComb>()) && buff != null && !Player.HasBuff(buff.Type) && Regeneration) Player.lifeRegen += 4;
 				if (!Player.HasBuff(ModContent.BuffType<Buffs.CalamityComb>()) && buff != null && !Player.HasBuff(buff.Type) && Lifeforce)
@@ -155,45 +155,45 @@ namespace AlchemistNPCLite
 					Player.statLifeMax2 += Player.statLifeMax / 5 / 20 * 20;
 				}
 			}
-            if (Calamity == null)
-            {
-                if (AllDamage10) Player.GetDamage(DamageClass.Generic) += 0.1f;
-                if (AllCrit10)
-                {
-                    Player.GetCritChance(DamageClass.Melee) += 10;
-                    Player.GetCritChance(DamageClass.Ranged) += 10;
-                    Player.GetCritChance(DamageClass.Magic) += 10;
-                    Player.GetCritChance(DamageClass.Throwing) += 10;
-                    // IMPLEMENT WHEN WEAKREFERENCES FIXED
-                    /*
-                    if (ModLoader.GetMod("ThoriumMod") != null)
-                    {
-                        ThoriumBoosts(Player);
-                    }
-                    if (ModLoader.GetMod("Redemption") != null)
-                    {
-                        RedemptionBoost(Player);
-                    }
-                    */
-                }
-                if (Regeneration) Player.lifeRegen += 4;
-                if (Lifeforce)
-                {
-                    Player.lifeForce = true;
-                    Player.statLifeMax2 += Player.statLifeMax / 5 / 20 * 20;
-                }
-            }
+			if (Calamity == null)
+			{
+				if (AllDamage10) Player.GetDamage(DamageClass.Generic) += 0.1f;
+				if (AllCrit10)
+				{
+					Player.GetCritChance(DamageClass.Melee) += 10;
+					Player.GetCritChance(DamageClass.Ranged) += 10;
+					Player.GetCritChance(DamageClass.Magic) += 10;
+					Player.GetCritChance(DamageClass.Throwing) += 10;
+					// IMPLEMENT WHEN WEAKREFERENCES FIXED
+					/*
+					if (ModLoader.GetMod("ThoriumMod") != null)
+					{
+						ThoriumBoosts(Player);
+					}
+					if (ModLoader.GetMod("Redemption") != null)
+					{
+						RedemptionBoost(Player);
+					}
+					*/
+				}
+				if (Regeneration) Player.lifeRegen += 4;
+				if (Lifeforce)
+				{
+					Player.lifeForce = true;
+					Player.statLifeMax2 += Player.statLifeMax / 5 / 20 * 20;
+				}
+			}
 
-            if (MS) Player.moveSpeed += 0.25f;
-            if (Defense8) Player.statDefense += 8;
-            if (DR10) Player.endurance += 0.1f;
+			if (MS) Player.moveSpeed += 0.25f;
+			if (Defense8) Player.statDefense += 8;
+			if (DR10) Player.endurance += 0.1f;
 			if (Bewitched) ++Player.maxMinions;
 			if (Sharpen)
 			{
 				Player.GetArmorPenetration(DamageClass.Melee) += 12;
 				Player.GetArmorPenetration(DamageClass.Summon) += 12;
 			}
-			if (Clairvoyance) 
+			if (Clairvoyance)
 			{
 				Player.GetDamage(DamageClass.Magic) += 0.05f;
 				Player.GetCritChance(DamageClass.Magic) += 2;
@@ -201,7 +201,7 @@ namespace AlchemistNPCLite
 				Player.manaCost -= 0.02f;
 			}
 			if (AmmoBox) Player.ammoBox = true;
-			if (SugarRush) 
+			if (SugarRush)
 			{
 				Player.pickSpeed -= 0.2f;
 				Player.moveSpeed += 0.2f;
@@ -212,28 +212,28 @@ namespace AlchemistNPCLite
 				Main.SceneMetrics.HasHeartLantern = true;
 				Main.SceneMetrics.HasCampfire = true;
 			}
-        }
-        private void CalamityBoost(Player player)
-        {
-            // CalamityMod.CalPlayer.CalamityPlayer CalamityPlayer = Player.GetModPlayer<CalamityMod.CalPlayer.CalamityPlayer>();
-            // CalamityPlayer.throwingCrit += 10;
-            player.GetCritChance<ThrowingDamageClass>() += 10;
-        }
-        // IMPLEMENT WHEN WEAKREFERENCES FIXED
-        /*
-        private void RedemptionBoost(Player player)
-        {
-            Redemption.Items.DruidDamageClass.DruidDamagePlayer RedemptionPlayer = Player.GetModPlayer<Redemption.Items.DruidDamageClass.DruidDamagePlayer>();
-            RedemptionPlayer.druidCrit += 10;
-        }
-        private void ThoriumBoosts(Player player)
-        {
-            ThoriumMod.ThoriumPlayer ThoriumPlayer = Player.GetModPlayer<ThoriumMod.ThoriumPlayer>();
-            ThoriumPlayer.symphonicCrit += 10;
-            ThoriumPlayer.radiantCrit += 10;
-        }
+		}
+		private void CalamityBoost(Player player)
+		{
+			// CalamityMod.CalPlayer.CalamityPlayer CalamityPlayer = Player.GetModPlayer<CalamityMod.CalPlayer.CalamityPlayer>();
+			// CalamityPlayer.throwingCrit += 10;
+			player.GetCritChance<ThrowingDamageClass>() += 10;
+		}
+		// IMPLEMENT WHEN WEAKREFERENCES FIXED
+		/*
+		private void RedemptionBoost(Player player)
+		{
+			Redemption.Items.DruidDamageClass.DruidDamagePlayer RedemptionPlayer = Player.GetModPlayer<Redemption.Items.DruidDamageClass.DruidDamagePlayer>();
+			RedemptionPlayer.druidCrit += 10;
+		}
+		private void ThoriumBoosts(Player player)
+		{
+			ThoriumMod.ThoriumPlayer ThoriumPlayer = Player.GetModPlayer<ThoriumMod.ThoriumPlayer>();
+			ThoriumPlayer.symphonicCrit += 10;
+			ThoriumPlayer.radiantCrit += 10;
+		}
 		*/
-		
+
 		private bool QuickBuff_ShouldBotherUsingThisBuff(int attemptedType)
 		{
 			bool result = true;
@@ -277,17 +277,17 @@ namespace AlchemistNPCLite
 			return result;
 		}
 
-        public override void ProcessTriggers(TriggersSet triggersSet)
-        {
-            if (DistantPotionsUse && PlayerInput.Triggers.Current.QuickBuff)
-            {
-                SoundStyle type1 = SoundID.Item3;
+		public override void ProcessTriggers(TriggersSet triggersSet)
+		{
+			if (DistantPotionsUse && PlayerInput.Triggers.Current.QuickBuff)
+			{
+				SoundStyle type1 = SoundID.Item3;
 				bool flag = true;
 				bool dosound = false;
-                for (int index1 = 0; index1 < 40; ++index1)
-                {
+				for (int index1 = 0; index1 < 40; ++index1)
+				{
 					flag = true;
-                    if (Player.CountBuffs() == 22) return;
+					if (Player.CountBuffs() == 22) return;
 					Item bankitem = Player.bank.item[index1];
 					if (bankitem.stack <= 0 || bankitem.type <= 0 || bankitem.buffType <= 0 || bankitem.CountsAsClass(DamageClass.Summon))
 					{
@@ -349,6 +349,7 @@ namespace AlchemistNPCLite
 					{
 						continue;
 					}
+					ItemLoader.UseItem(bankitem, Player);
 					int num3 = bankitem.buffTime;
 					if (num3 == 0)
 					{
@@ -361,130 +362,74 @@ namespace AlchemistNPCLite
 					}
 					dosound = true;
 
-					if (bankitem.consumable)
+					if (bankitem.consumable && ItemLoader.ConsumeItem(bankitem, Player))
 					{
-						if (AlchemistCharmTier4 == true)
-						{
-							ModLoader.TryGetMod("CalamityMod", out Mod Calamity);
-							if (Calamity != null)
-							{
-								if ((bool)Calamity.Call("Downed", "supreme calamitas"))
-								{
-								}
-								else if (Main.rand.NextFloat() >= .25f)
-								{
-								}
-								else
-								{
-									--bankitem.stack;
-								}
-							}
-							else if (Main.rand.NextFloat() >= .25f)
-							{
-							}
-							else
-							{
-								--bankitem.stack;
-							}
-						}
-
-						else if (AlchemistCharmTier3 == true)
-						{
-							if (Main.rand.Next(2) == 0)
-							{
-							}
-							else
-							{
-								--bankitem.stack;
-							}
-						}
-
-						else if (AlchemistCharmTier2 == true)
-						{
-							if (Main.rand.Next(4) == 0)
-							{
-							}
-							else
-							{
-								--bankitem.stack;
-							}
-						}
-
-						else if (AlchemistCharmTier1 == true)
-						{
-							if (Main.rand.Next(10) == 0)
-							{
-							}
-							else
-							{
-								--bankitem.stack;
-							}
-						}
-						else
-						{
-							--bankitem.stack;
-						}
+						--bankitem.stack;
 						if (bankitem.stack <= 0)
 							bankitem.TurnToAir();
 					}
+					if (Player.CountBuffs() == Player.MaxBuffs)
+					{
+						break;
+					}
 				}
-                //if (type1 == null)
-                    //return;
-                if (dosound) SoundEngine.PlaySound(type1, Player.position);
-                //Recipe.FindRecipes();
-            }
-            if (AlchemistNPCLite.DiscordBuff.JustPressed)
-            {
-                if (Main.myPlayer == Player.whoAmI && Player.HasBuff(ModContent.BuffType<Buffs.DiscordBuff>()))
-                {
-                    Vector2 vector2 = Main.screenPosition + new Vector2(Main.mouseX, Main.mouseY);
-                    if (!Collision.SolidCollision(vector2, Player.width, Player.height))
-                    {
-                        Player.Teleport(vector2, 1, 0);
-                        NetMessage.SendData(65, -1, -1, (NetworkText)null, 0, (float)Player.whoAmI, (float)vector2.X, (float)vector2.Y, 1, 0, 0);
-                        if (Player.chaosState)
-                        {
-                            Player.statLife = Player.statLife - Player.statLifeMax2 / 3;
-                            PlayerDeathReason damageSource = PlayerDeathReason.ByOther(13);
-                            if (Main.rand.Next(2) == 0)
-                                damageSource = PlayerDeathReason.ByOther(Player.Male ? 14 : 15);
-                            if (Player.statLife <= 0)
-                                Player.KillMe(damageSource, 1.0, 0, false);
-                            Player.lifeRegenCount = 0;
-                            Player.lifeRegenTime = 0;
-                        }
-                        Player.AddBuff(88, 600, true);
-                        Player.AddBuff(164, 60, true);
-                    }
-                }
-                if (Main.myPlayer == Player.whoAmI && Player.HasBuff(ModContent.BuffType<Buffs.TrueDiscordBuff>()))
-                {
-                    Vector2 vector2 = Main.screenPosition + new Vector2(Main.mouseX, Main.mouseY);
-                    if (!Collision.SolidCollision(vector2, Player.width, Player.height))
-                    {
-                        Player.Teleport(vector2, 1, 0);
-                        NetMessage.SendData(65, -1, -1, (NetworkText)null, 0, (float)Player.whoAmI, (float)vector2.X, (float)vector2.Y, 1, 0, 0);
-                        if (Player.chaosState)
-                        {
-                            Player.statLife = Player.statLife - Player.statLifeMax2 / 7;
-                            PlayerDeathReason damageSource = PlayerDeathReason.ByOther(13);
-                            if (Main.rand.Next(2) == 0)
-                                damageSource = PlayerDeathReason.ByOther(Player.Male ? 14 : 15);
-                            if (Player.statLife <= 0)
-                                Player.KillMe(damageSource, 1.0, 0, false);
-                            Player.lifeRegenCount = 0;
-                            Player.lifeRegenTime = 0;
-                        }
-                        Player.AddBuff(88, 360, true);
-                    }
-                }
-            }
-        }
-        // IMPLEMENT
-        // private void CalamityRage(Player player)
-        // {
-        //     CalamityMod.CalPlayer.CalamityPlayer CalamityPlayer = Player.GetModPlayer<CalamityMod.CalPlayer.CalamityPlayer>();
-        //     CalamityPlayer.rage = CalamityPlayer.rageMax;
-        // }
-    }
+				//if (type1 == null)
+				//return;
+				if (dosound) SoundEngine.PlaySound(type1, Player.position);
+				//Recipe.FindRecipes();
+			}
+			if (AlchemistNPCLite.DiscordBuff.JustPressed)
+			{
+				if (Main.myPlayer == Player.whoAmI && Player.HasBuff(ModContent.BuffType<Buffs.DiscordBuff>()))
+				{
+					Vector2 vector2 = Main.screenPosition + new Vector2(Main.mouseX, Main.mouseY);
+					if (!Collision.SolidCollision(vector2, Player.width, Player.height))
+					{
+						Player.Teleport(vector2, 1, 0);
+						NetMessage.SendData(65, -1, -1, (NetworkText)null, 0, (float)Player.whoAmI, (float)vector2.X, (float)vector2.Y, 1, 0, 0);
+						if (Player.chaosState)
+						{
+							Player.statLife = Player.statLife - Player.statLifeMax2 / 3;
+							PlayerDeathReason damageSource = PlayerDeathReason.ByOther(13);
+							if (Main.rand.Next(2) == 0)
+								damageSource = PlayerDeathReason.ByOther(Player.Male ? 14 : 15);
+							if (Player.statLife <= 0)
+								Player.KillMe(damageSource, 1.0, 0, false);
+							Player.lifeRegenCount = 0;
+							Player.lifeRegenTime = 0;
+						}
+						Player.AddBuff(88, 600, true);
+						Player.AddBuff(164, 60, true);
+					}
+				}
+				if (Main.myPlayer == Player.whoAmI && Player.HasBuff(ModContent.BuffType<Buffs.TrueDiscordBuff>()))
+				{
+					Vector2 vector2 = Main.screenPosition + new Vector2(Main.mouseX, Main.mouseY);
+					if (!Collision.SolidCollision(vector2, Player.width, Player.height))
+					{
+						Player.Teleport(vector2, 1, 0);
+						NetMessage.SendData(65, -1, -1, (NetworkText)null, 0, (float)Player.whoAmI, (float)vector2.X, (float)vector2.Y, 1, 0, 0);
+						if (Player.chaosState)
+						{
+							Player.statLife = Player.statLife - Player.statLifeMax2 / 7;
+							PlayerDeathReason damageSource = PlayerDeathReason.ByOther(13);
+							if (Main.rand.Next(2) == 0)
+								damageSource = PlayerDeathReason.ByOther(Player.Male ? 14 : 15);
+							if (Player.statLife <= 0)
+								Player.KillMe(damageSource, 1.0, 0, false);
+							Player.lifeRegenCount = 0;
+							Player.lifeRegenTime = 0;
+						}
+						Player.AddBuff(88, 360, true);
+					}
+				}
+			}
+		}
+		// IMPLEMENT
+		// private void CalamityRage(Player player)
+		// {
+		//     CalamityMod.CalPlayer.CalamityPlayer CalamityPlayer = Player.GetModPlayer<CalamityMod.CalPlayer.CalamityPlayer>();
+		//     CalamityPlayer.rage = CalamityPlayer.rageMax;
+		// }
+	}
 }


### PR DESCRIPTION
Quickbuffs from personal storage was not affected by duration increases from alchemist charms. A call to `ItemLoader.UseItem()` should fix that.

Also simplified the check for the chance to not consume potions for bank quickbuff

Also converted indentation in AlchemistNPCLitePlayer.cs to spaces

(original lines 366-422 were replaced with a call to `ItemLoader.ConsumeItem()` to reuse the code contained in `AlchemistGlobalItem`. The diff noise after that is just because of the indentation changes)